### PR TITLE
feat: DID Auth 기능

### DIFF
--- a/src/AliceInquirer.ts
+++ b/src/AliceInquirer.ts
@@ -53,7 +53,7 @@ export class AliceInquirer extends BaseInquirer {
     this.alice = alice
     this.listener = new Listener()
     this.promptOptionsString = Object.values(PromptOptions)
-    this.listener.messageListener(this.alice.agent, this.alice.name)
+    this.listener.messageListener(this.alice, this.alice.name)
   }
 
   public static async build(): Promise<AliceInquirer> {

--- a/src/BaseAgent.ts
+++ b/src/BaseAgent.ts
@@ -21,7 +21,7 @@ import {
   Agent,
   HttpOutboundTransport,
 } from '@aries-framework/core'
-import { IndyVdrIndyDidResolver, IndyVdrAnonCredsRegistry, IndyVdrModule } from '@aries-framework/indy-vdr'
+import { IndyVdrIndyDidResolver, IndyVdrAnonCredsRegistry, IndyVdrModule,IndyVdrIndyDidRegistrar } from '@aries-framework/indy-vdr'
 import { agentDependencies, HttpInboundTransport } from '@aries-framework/node'
 import { anoncreds } from '@hyperledger/anoncreds-nodejs'
 import { ariesAskar, ariesAskarNodeJS } from '@hyperledger/aries-askar-nodejs'
@@ -131,6 +131,7 @@ function getAskarAnonCredsIndyModules() {
     }),
     dids: new DidsModule({
       resolvers: [new IndyVdrIndyDidResolver()],
+      registrars: [new IndyVdrIndyDidRegistrar],
     }),
     askar: new AskarModule({
       ariesAskar,

--- a/src/Listener.ts
+++ b/src/Listener.ts
@@ -1,4 +1,5 @@
 import type { Alice } from './Alice'
+import {Key as AskarKey, KeyAlgs} from '@hyperledger/aries-askar-shared'
 import type { AliceInquirer } from './AliceInquirer'
 import type {
   Agent,
@@ -10,17 +11,21 @@ import type {
 } from '@aries-framework/core'
 import type BottomBar from 'inquirer/lib/ui/bottom-bar'
 
+import { Buffer as ariesBuffer, isValidPrivateKey, KeyType } from '@aries-framework/core'
+import { CustomRecord} from './interfaces/record'
 import {
   BasicMessageEventTypes,
   BasicMessageRole,
   CredentialEventTypes,
   CredentialState,
+  DidRecord,
   ProofEventTypes,
   ProofState,
 } from '@aries-framework/core'
 import { ui } from 'inquirer'
 
 import { Color, purpleText } from './OutputClass'
+import { toBase64 } from './utis'
 
 export class Listener {
   public on: boolean
@@ -68,10 +73,33 @@ export class Listener {
     )
   }
 
-  public messageListener(agent: Agent, name: string) {
-    agent.events.on(BasicMessageEventTypes.BasicMessageStateChanged, async (event: BasicMessageStateChangedEvent) => {
+  public async messageListener(alice: Alice, name: string) : Promise<any> {
+    alice.agent.events.on(BasicMessageEventTypes.BasicMessageStateChanged, async (event: BasicMessageStateChangedEvent) => {
       if (event.payload.basicMessageRecord.role === BasicMessageRole.Receiver) {
         this.ui.updateBottomBar(purpleText(`\n${name} received a message: ${event.payload.message.content}\n`))
+        //did auth를 위한 문자열 수신
+        try{
+          const jsonObject = JSON.parse(event.payload.message.content);
+          if (jsonObject.hasOwnProperty("DIDMessage")){
+            const record = await alice.storage.getById(alice.agent.context,CustomRecord,"key") as unknown as DidRecord
+            const val = record.metadata.get("privateKey") as Array<string>;
+            const privateKey = val[0].split(',');
+            const secretKey = new ariesBuffer(privateKey)
+            if(isValidPrivateKey(secretKey,KeyType.Ed25519)){
+              const key = AskarKey.fromSecretBytes({secretKey:secretKey,algorithm:KeyAlgs.Ed25519})
+              const signature = toBase64(key.signMessage({message:new Uint8Array(jsonObject.DIDMessage)}))
+              const message = {
+                did: alice.did,
+                signature,
+              }
+              alice.sendMessage(JSON.stringify(message));
+            }else{
+              new Error("invalid private key")
+            } 
+          }
+        }catch (err){
+          console.log(err);
+        }
       }
     })
   }

--- a/src/interfaces/IIssueCredentialInfo.ts
+++ b/src/interfaces/IIssueCredentialInfo.ts
@@ -1,0 +1,8 @@
+export interface IVoteIssueCredentialInfo{
+        vc : string;
+        room : string;
+}
+
+export interface IDidIssueCredentialInfo{
+        did:string;
+}

--- a/src/interfaces/IItemObject.ts
+++ b/src/interfaces/IItemObject.ts
@@ -1,0 +1,3 @@
+export interface IItemObject{
+    [key:string]:any;
+}

--- a/src/interfaces/record.ts
+++ b/src/interfaces/record.ts
@@ -1,0 +1,30 @@
+import type { TagsBase } from "@aries-framework/core"
+
+import { BaseRecord } from "@aries-framework/core"
+import { Metadata } from "@aries-framework/core/build/storage/Metadata";
+export class CustomRecord extends BaseRecord{
+    public getTags(): TagsBase{
+      return {}
+    }
+  }
+
+  interface DidTags extends TagsBase {
+    publicKey: string;
+    privateKey: string; 
+  }
+  
+export class DidRecord extends BaseRecord<TagsBase, DidTags> {
+    readonly type = 'CustomRecord';
+  
+    constructor(id: string, createdAt: Date, metadata: Metadata<{}>) {
+      super();
+      this.id = id;
+      this.createdAt = createdAt;
+      this.metadata = metadata;
+    }
+  
+    // Custom tags를 포함한 모든 태그 반환
+    getTags(): DidTags {
+      return this._tags;
+    }
+  }

--- a/src/utis.ts
+++ b/src/utis.ts
@@ -1,0 +1,10 @@
+const toBase64 = (uint8Array:Uint8Array) =>{
+    let binary = '';
+    const len = uint8Array.byteLength;
+    for (let i = 0; i < len; i++) {
+        binary += String.fromCharCode(uint8Array[i]);
+    }
+    return btoa(binary);
+}
+
+export {toBase64}


### PR DESCRIPTION
## feat: DID Auth 기능

### VC를 받기전에 사용자의 DID를 검증

- 사용자 측의 SSI앱에서 did발급
- 회원가입 시 DID를 같이 등록
- 이후 유권자로 등록되고 VC를 발급받는경우 다음과 같은 단계의 검증이 이루어진다.
1. 회원 인증(로그인)
2. 회원가입  시 등록한 DID가 맞는지
3. DID Auth

### 검증과정
0. 사용자는 회원가입 시 본인의 did를 입력

1. 사용자는 시스템에 로그인한다.
2. 사용자는 마이페이지에 접속한다.
(유권자로 등록된 경우 해당 투표방에대한 VC발급가능)
3. 투표권발급을 누른다.
4. 회원가입 시 등록된 사용자의 DID가 맞는지 검증
5. 시스템은 사용자에게 랜덤한 문자열을 전송
	crypto.randomBytes(16)
6. 사용자는 본인의 privateKey로 서명 후 did와 함께 시스템으로 전송
	처음 사용자는 client앱을 시작하면 did를 발급받는데
	did발급 시 privateKey, publicKey를 추가적으로 발급받는다.
	이를 wallet에 저장해두고 didAuth과정에서 사용.
	통신 시 데이터는 json형식으로 전송되기때문에 Uint8Array형식인 signature를 안전하게 전송하기위해
	base64로 인코딩하여 전송한다.
7. 시스템은 사용자의 did로 document를 가져온 후 사용자의 publicKey로 검증
	document의 publicKey는 Base58로 인코딩되어있기때문에 이를 디코딩한다.
	이 publicKey로 만든 객체로 처음 생성한 message와 signature를 검증
8. 검증에 성공할 경우 시스템은 사용자에게 투표방에 대한 VC를 발급한다.